### PR TITLE
fix: provide QueryClient for react-query

### DIFF
--- a/src/components/App/App.component.js
+++ b/src/components/App/App.component.js
@@ -3,6 +3,7 @@
 import './app.css';
 import React from 'react';
 import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { AppContents } from './AppContents.component';
 import {
     RulesEngineVerboseInitializer,
@@ -16,16 +17,20 @@ type Props = {
     store: ReduxStore,
 };
 
+const queryClient = new QueryClient();
+
 export const App = ({ store }: Props) => (
     <React.Fragment>
         <Provider
             store={store}
         >
-            <MetadataAutoSelectInitializer>
-                <RulesEngineVerboseInitializer>
-                    <AppContents />
-                </RulesEngineVerboseInitializer>
-            </MetadataAutoSelectInitializer>
+            <QueryClientProvider client={queryClient}>
+                <MetadataAutoSelectInitializer>
+                    <RulesEngineVerboseInitializer>
+                        <AppContents />
+                    </RulesEngineVerboseInitializer>
+                </MetadataAutoSelectInitializer>
+            </QueryClientProvider>
         </Provider>
     </React.Fragment>
 );


### PR DESCRIPTION
## Summary
- wrap app in `QueryClientProvider` so React Query hooks have a client

## Testing
- `npx jest src/core_modules/capture-core/rules/__tests__/rulesEngine.test.js` *(fails: localStorage is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_6894f9d586148325b46d977a9ccd2ca7