### PR TITLE
fix: correct package paths for rules-engine workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "scripts": {
     "start": "yarn verifyCacheVersion && concurrently --kill-others \"yarn workspaces run build:watch\" \"d2-app-scripts start\"",
     "start:forCypress": "yarn workspaces run build && node scripts/startAppForCypress.js",
-    "build": "yarn verifyCacheVersion && yarn workspaces run build && GENERATE_SOURCEMAP=false d2-app-scripts build && cp ./package.json ./build/app/package.json",
-    "build:standalone": "yarn workspaces run build && GENERATE_SOURCEMAP=false d2-app-scripts build --standalone",
+    "build": "yarn verifyCacheVersion && yarn workspaces run build && node scripts/buildApp.js && node scripts/copyPackageJson.js",
+    "build:standalone": "yarn workspaces run build && node scripts/buildApp.js --standalone",
     "test": "yarn workspaces run build && d2-app-scripts test",
     "test:debug": "yarn workspaces run build && react-scripts --inspect-brk test --runInBand",
     "jsdoc": "NODE_ENV=development jsdoc -c jsdoc-conf.json",

--- a/packages/rules-engine/package.json
+++ b/packages/rules-engine/package.json
@@ -2,7 +2,7 @@
     "name": "@dhis2/rules-engine-javascript",
     "version": "103.2.4",
     "license": "BSD-3-Clause",
-    "main": "./build\\cjs\\index.js",
+    "main": "./build/cjs/index.js",
     "scripts": {
         "linter:check": "eslint -c .eslintrc . --quiet",
         "build": "d2-app-scripts build",
@@ -14,9 +14,9 @@
         "d2-utilizr": "^0.2.15",
         "loglevel": "^1.9.1"
     },
-    "module": "./build\\es\\index.js",
+    "module": "./build/es/index.js",
     "exports": {
-        "import": "./build\\es\\index.js",
-        "require": "./build\\cjs\\index.js"
+        "import": "./build/es/index.js",
+        "require": "./build/cjs/index.js"
     }
 }

--- a/scripts/buildApp.js
+++ b/scripts/buildApp.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+
+const result = spawnSync('d2-app-scripts', ['build', ...args], {
+    stdio: 'inherit',
+    env: { ...process.env, GENERATE_SOURCEMAP: 'false' },
+    shell: true,
+});
+
+if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+}

--- a/scripts/copyPackageJson.js
+++ b/scripts/copyPackageJson.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = path.resolve(__dirname, '..', 'package.json');
+const destDir = path.resolve(__dirname, '..', 'build', 'app');
+const dest = path.join(destDir, 'package.json');
+
+fs.mkdirSync(destDir, { recursive: true });
+fs.copyFileSync(src, dest);


### PR DESCRIPTION
## Summary
- fix rules-engine package.json to use forward slashes
- run build via node scripts for cross-platform compatibility

## Testing
- `yarn test` *(fails: Error when performing request to registry.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_6895dfe054a48325a67b0f1f9f991f1c